### PR TITLE
feat: add support to pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: cc-template-scanner
   name: Cloud Conformity Template Scanner
   description: "Scans CloudFormation templates before they're deployed."
-  entry: index
+  entry: conformity-scan
   language: node

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+- id: cc-template-scanner
+  name: Cloud Conformity Template Scanner
+  description: "Scans CloudFormation templates before they're deployed."
+  entry: index
+  language: node


### PR DESCRIPTION
Git hook scripts are useful for identifying simple issues before submission to code review (adding more preventive measure). This hook enables developers to scan cloudformation templates on every commit they do. 

Failing commit due to misconfigurations found in the template.
=======
![image](https://user-images.githubusercontent.com/23138401/187399132-ef0f4891-a2ab-40c2-9944-a15870833370.png)

Template passes configuration checks.
=======
![image](https://user-images.githubusercontent.com/23138401/187399659-c7d60a4a-960d-4aa3-b3dd-64f24bb46c9d.png)
